### PR TITLE
Benchmark Controller: problem+json response for invalid parameter

### DIFF
--- a/src/main/java/com/cse/ngsa/app/controllers/BenchmarkController.java
+++ b/src/main/java/com/cse/ngsa/app/controllers/BenchmarkController.java
@@ -19,7 +19,7 @@ import reactor.core.publisher.Mono;
 @Api(tags = "Benchmark")
 public class BenchmarkController extends Controller {
   private static final Logger logger = LogManager.getLogger(BenchmarkController.class);
-  public static final int MaxBenchStrSize = 1024 * 1024;
+  private static final int MaxBenchStrSize = 1024 * 1024;
   /* Java 1.5+
   private final String repeatedBenchString = 
           new String(new char[1024 * 1024 / 16]).replace("\0", "0123456789ABCDEF");
@@ -43,14 +43,9 @@ public class BenchmarkController extends Controller {
       ServerHttpRequest request
   ) {
 
-    if (Boolean.TRUE == validator.isValidBenchmarkSize(benchmarkSizeStr)) {
+    if (Boolean.TRUE == validator.isValidBenchmarkSize(benchmarkSizeStr, MaxBenchStrSize)) {
 
       int benchmarkSize = Integer.parseInt(benchmarkSizeStr);
-      // return Mono.just(newString) causes exception
-      // TODO: We can just return response entity without Mono
-      // return ResponseEntity.ok()
-      //     .contentType(MediaType.TEXT_PLAIN)
-      //     .body(newString);
       return Mono.justOrEmpty(ResponseEntity.ok(
           benchmarkString.substring(0, benchmarkSize)));
 

--- a/src/main/java/com/cse/ngsa/app/controllers/BenchmarkController.java
+++ b/src/main/java/com/cse/ngsa/app/controllers/BenchmarkController.java
@@ -4,22 +4,22 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 @RestController
-@RequestMapping(path = "/api/benchmark", produces = MediaType.TEXT_PLAIN_VALUE)
+@RequestMapping(path = "/api/benchmark", produces = {MediaType.TEXT_PLAIN_VALUE,
+    MediaType.APPLICATION_PROBLEM_JSON_VALUE})
 @Api(tags = "Benchmark")
-public class BenchmarkController {
+public class BenchmarkController extends Controller {
   private static final Logger logger = LogManager.getLogger(BenchmarkController.class);
-  private static final int MaxBenchStrSize = 1024 * 1024;
+  public static final int MaxBenchStrSize = 1024 * 1024;
   /* Java 1.5+
   private final String repeatedBenchString = 
           new String(new char[1024 * 1024 / 16]).replace("\0", "0123456789ABCDEF");
@@ -33,39 +33,36 @@ public class BenchmarkController {
   }
 
   /** getBenchmark. */
-  @GetMapping(
-      value = "/{size}",
-      produces = MediaType.TEXT_PLAIN_VALUE)
-  public Mono<String> getBenchmark(
+  @GetMapping(value = "/{size}")
+  @SuppressWarnings({"squid:S2629", "squid:S1612"})  
+  public Mono<ResponseEntity<String>> getBenchmark(
       @ApiParam(value = "The size of the benchmark data ( 0 < size <= 1MB )",
                 example = "214", required = true)
       @PathVariable("size")
-      int benchmarkSize,
+      String benchmarkSizeStr,
       ServerHttpRequest request
   ) {
 
-    try {
-      if (benchmarkSize < 1) {
-        var err = "Invalid Size. Size must be > 0";
-        logger.error(err);
+    if (Boolean.TRUE == validator.isValidBenchmarkSize(benchmarkSizeStr)) {
 
-        return Mono.error(new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, String.format("Benchmark Error: %s", err)));
+      int benchmarkSize = Integer.parseInt(benchmarkSizeStr);
+      // return Mono.just(newString) causes exception
+      // TODO: We can just return response entity without Mono
+      // return ResponseEntity.ok()
+      //     .contentType(MediaType.TEXT_PLAIN)
+      //     .body(newString);
+      return Mono.justOrEmpty(ResponseEntity.ok(
+          benchmarkString.substring(0, benchmarkSize)));
 
-      } else if (benchmarkSize > MaxBenchStrSize) {
-        var err = "Invalid Size. Size must be <= 1024 * 1024 (1 MB)";
-        logger.error(err);
+    } else {
 
-        return Mono.error(new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, String.format("Benchmark Error: %s", err)));
-      }
+      String invalidResponse = super.invalidParameterResponses
+          .invalidBenchmarkSizeResponse(request.getURI().getPath());
+      logger.error("Benchmark data size parameter should be 0 < size <= 1024*1024");
 
-      return Mono.just(benchmarkString.substring(0, benchmarkSize));
-    } catch (Exception ex) {
-      logger.error("Error received in BenchmarkController", ex);
-
-      return Mono.error(new ResponseStatusException(
-        HttpStatus.INTERNAL_SERVER_ERROR, "benchmark Error"));
+      return Mono.just(ResponseEntity.badRequest()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .body(invalidResponse));
     }
   }
 }

--- a/src/main/java/com/cse/ngsa/app/utils/InvalidParameterResponses.java
+++ b/src/main/java/com/cse/ngsa/app/utils/InvalidParameterResponses.java
@@ -55,6 +55,12 @@ public class InvalidParameterResponses {
       "The parameter 'movieId' should start with 'tt' and be between 7 and 11 characters in total."
       );
 
+  private static final String BENCHMARK_SIZE_ERROR = String.format(
+      VALIDATION_ERROR_TEMPLATE,
+      "benchmarkSize",
+      "The parameter 'benchmarkSize' should be a number greater than 0 and less than 1024*1024"
+      );
+
   public enum SearchParameter {
     Q,
     PAGE_SIZE,
@@ -124,6 +130,10 @@ public class InvalidParameterResponses {
 
   public String invalidMovieDirectReadResponse(String instance) {
     return response(DOC_URL + "#movies-direct-read", instance, MOVIEID_ERROR);
+  }
+
+  public String invalidBenchmarkSizeResponse(String instance) {
+    return response(DOC_URL, instance, BENCHMARK_SIZE_ERROR);
   }
   
 }

--- a/src/main/java/com/cse/ngsa/app/utils/ParameterValidator.java
+++ b/src/main/java/com/cse/ngsa/app/utils/ParameterValidator.java
@@ -1,5 +1,6 @@
 package com.cse.ngsa.app.utils;
 
+import com.cse.ngsa.app.controllers.BenchmarkController;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -139,4 +140,18 @@ public class ParameterValidator {
     return true;
   }
 
+  /** isValidRating. */
+  public Boolean isValidBenchmarkSize(String benchmarkSizeStr) {
+    if (!StringUtils.isEmpty(benchmarkSizeStr)) {
+      try {
+        int benchmarkSize = Integer.parseInt(benchmarkSizeStr);
+        if (benchmarkSize < 0 || benchmarkSize > BenchmarkController.MaxBenchStrSize) {
+          return false;
+        }
+      } catch (Exception ex) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/src/main/java/com/cse/ngsa/app/utils/ParameterValidator.java
+++ b/src/main/java/com/cse/ngsa/app/utils/ParameterValidator.java
@@ -1,6 +1,5 @@
 package com.cse.ngsa.app.utils;
 
-import com.cse.ngsa.app.controllers.BenchmarkController;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -141,11 +140,11 @@ public class ParameterValidator {
   }
 
   /** isValidRating. */
-  public Boolean isValidBenchmarkSize(String benchmarkSizeStr) {
+  public Boolean isValidBenchmarkSize(String benchmarkSizeStr, int maxBenchStrSize) {
     if (!StringUtils.isEmpty(benchmarkSizeStr)) {
       try {
         int benchmarkSize = Integer.parseInt(benchmarkSizeStr);
-        if (benchmarkSize < 0 || benchmarkSize > BenchmarkController.MaxBenchStrSize) {
+        if (benchmarkSize < 0 || benchmarkSize > maxBenchStrSize) {
           return false;
         }
       } catch (Exception ex) {
@@ -154,4 +153,5 @@ public class ParameterValidator {
     }
     return true;
   }
+
 }


### PR DESCRIPTION
Proper problem+json response to benchmark controller for invalid parameter.

## Notes:
- Refactored code
  - Moved validation to `ParameterValidation.java`
  - @jofultz Didn't use exception for consistency with other controllers
  - Size parameter is String type to properly handle and return error message for invalid params (e.g `/benchmark/abcd`)
- `getBenchmark` now returns `Mono<ResponseEntity<String>>` instead of `Mono<String>`
  - Tried to follow MoviesController, but with plain Mono<string> type (and probably for two content type annotation) exceptions were thrown. Used `ResponseEntity` to properly set different content types and body
  - Function return type of Object was ambiguous, hence used concrete type
  - Suggestion: we can return `ResponseEntity<String>` instead of `Mono<>`
- Added consistent error message and parameter validation

## Closes

- Close #182
- Close #183