### PR TITLE
Added X-Load-Feedback header for bursting

### DIFF
--- a/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -6,6 +6,7 @@ import com.cse.ngsa.app.dao.ActorsDao;
 import com.cse.ngsa.app.dao.GenresDao;
 import com.cse.ngsa.app.dao.MoviesDao;
 import com.cse.ngsa.app.health.ietf.IeTfStatus;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -16,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -58,13 +60,26 @@ public class HealthzController {
 
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
+    HttpHeaders headers = new HttpHeaders();
+
+
+    long cpuLoad = Math.round(ManagementFactory.getPlatformMXBean(
+            com.sun.management.OperatingSystemMXBean.class).getProcessCpuLoad() * 100L);
+
+    headers.add("X-Load-Feedback",
+        String.format("service=%s, current-load=%s, target-load=%s, max-load=%s ",
+        environment.getProperty("service.name"),
+        cpuLoad,
+        environment.getProperty("cpu.target.load"),
+        environment.getProperty("cpu.max.load")));
+
     return resultsMono.map(data -> {
       String healthStatus = getOverallHealthStatus(data);
       int resCode = healthStatus.equals(IeTfStatus.FAIL.name())
           ? HttpStatus.SERVICE_UNAVAILABLE.value()
           : HttpStatus.OK.value();
       return new ResponseEntity<>(healthStatus,
-          null,
+          headers,
           HttpStatus.valueOf(resCode));
     });
   }
@@ -90,7 +105,7 @@ public class HealthzController {
       webInstanceRole = "unknown";
     }
 
-    ieTfResult.put("serviceId", "ngsa-java");
+    ieTfResult.put("serviceId", environment.getProperty("service.name"));
     ieTfResult.put("description", "Ngsa Java Health Check");
     ieTfResult.put("instance", webInstanceRole);
     ieTfResult.put("version", buildConfig.getBuildVersion());

--- a/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -61,8 +61,6 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-
-
     long cpuLoad = Math.round(ManagementFactory.getPlatformMXBean(
             com.sun.management.OperatingSystemMXBean.class).getProcessCpuLoad() * 100L);
 

--- a/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -116,6 +116,9 @@ public class CommonUtils {
     System.out.println("\r\nUsage:\r\n"
         + "   mvn clean spring-boot:run \r\n "
         + "\t-Dspring-boot.run.arguments=\" --help \r\n"
+        + "\t\t--service.name\r\n"
+        + "\t\t--cpu.target.load\r\n"
+        + "\t\t--cpu.max.load\r\n"
         + "\t\t--dry-run\r\n"
         + "\t\t--log-level=<trace|info|warn|error|fatal>\"");
   }

--- a/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -116,7 +116,6 @@ public class CommonUtils {
     System.out.println("\r\nUsage:\r\n"
         + "   mvn clean spring-boot:run \r\n "
         + "\t-Dspring-boot.run.arguments=\" --help \r\n"
-        + "\t\t--service.name\r\n"
         + "\t\t--cpu.target.load\r\n"
         + "\t\t--cpu.max.load\r\n"
         + "\t\t--dry-run\r\n"

--- a/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -116,8 +116,6 @@ public class CommonUtils {
     System.out.println("\r\nUsage:\r\n"
         + "   mvn clean spring-boot:run \r\n "
         + "\t-Dspring-boot.run.arguments=\" --help \r\n"
-        + "\t\t--auth-type=<CLI|MI|VS>\r\n"
-        + "\t\t--keyvault-name=<keyVaultName>\r\n"
         + "\t\t--dry-run\r\n"
         + "\t\t--log-level=<trace|info|warn|error|fatal>\"");
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,4 @@
-# If ngsa.environment.flag == CLI and you need a custom path
-# to the Azure profile and tokens then set the following two values.
-# Otherwise they will be ignored.
+service.name=ngsa-java
 server.port=4120
 
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M \\(%line\\) - %msg%n
@@ -16,3 +14,6 @@ spring.banner.location=classpath:static/startup-banner.txt
 
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=10s
+
+cpu.target.load=60
+cpu.max.load=80


### PR DESCRIPTION
Added X-Load-Feedback header for bursting

## Notes:
- Changed healthz route and added the header needed for bursting
- Refactor CommonUtils and removed keyVault references
- Added application properties needed for bursting

## Closes
Closes https://github.com/retaildevcrews/wcnp/issues/147
Closes https://github.com/retaildevcrews/wcnp/issues/184
Closes https://github.com/retaildevcrews/wcnp/issues/185
