### PR TITLE
Bugfix/request logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
@@ -137,6 +143,11 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <version>4.1.2</version>
+        </dependency>
+        <dependency>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+          <version>20210307</version>
         </dependency>
         </dependencies>
     <build>

--- a/src/main/java/com/cse/ngsa/app/middleware/RequestLogger.java
+++ b/src/main/java/com/cse/ngsa/app/middleware/RequestLogger.java
@@ -62,7 +62,8 @@ public class RequestLogger implements WebFilter {
       logData.put("Duration", duration);
       logData.put("Verb", currentRequest.getMethod().toString());
       logData.put("Path", pathQueryString);
-      logData.put("Host", currentRequest.getHeaders().getHost().toString());
+      InetSocketAddress host = currentRequest.getHeaders().getHost();
+      logData.put("Host", host == null ? "" : host.toString());
       logData.put("ClientIP", requestAddress);
       logData.put("UserAgent", userAgent);
       logData.put("CVector", "PLACEHOLDER-CV-VALUE");

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,0 +1,23 @@
+rootLogger.level = fatal
+rootLogger.appenderRef.stdout.ref = STDOUT
+logger.app.name=com.cse.ngsa
+logger.app.level=fatal
+logger.netty.name = io.netty
+logger.netty.level = fatal
+logger.reactor.name = io.reactivex
+logger.reactor.level = fatal
+# New Logger for RequestLogger object only
+logger.request.name=com.cse.ngsa.app.middleware.RequestLogger
+logger.request.level=fatal
+logger.request.appenderRef.stdout.ref=STDOUT_Request
+logger.request.additivity=false
+# New STDOUT Appender for Requestlogger
+appender.console_req.name = STDOUT_Request
+appender.console_req.type = Console
+appender.console_req.layout.type = PatternLayout
+appender.console_req.layout.pattern = %msg%n
+# STDOUT is a ConsoleAppender and uses PatternLayout.
+appender.console.name = STDOUT
+appender.console.type = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M \\(%line\\) - %msg%n

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -16,8 +16,3 @@ appender.console_req.name = STDOUT_Request
 appender.console_req.type = Console
 appender.console_req.layout.type = PatternLayout
 appender.console_req.layout.pattern = %msg%n
-# STDOUT is a ConsoleAppender and uses PatternLayout.
-appender.console.name = STDOUT
-appender.console.type = Console
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M \\(%line\\) - %msg%n


### PR DESCRIPTION
One bugfix and log changes:
- Added Log4j2 level properties for unit test. Now it will print only fatal logs from application, keeping unit test logs clean.
- Added Exclusion list for Maven test plugin. Otherwise, it was throwing JSONObject duplicate package warning. Added org.json dependency explicitly.
- Maven unit test does not set the HOST HTTP header. Hence it was silently throwing exception, and maven was catching it. Now it will check for empty HOST header and set to "" if not present

## Closes

- Closes https://github.com/retaildevcrews/wcnp/issues/216
- Closes https://github.com/retaildevcrews/wcnp/issues/218