### PR TITLE
Build Fail Fix: jforg removed snapshot builds of several Springfox artifacts

### DIFF
--- a/.github/workflows/ngsa.yaml
+++ b/.github/workflows/ngsa.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - bugfix/jfrog_https
 
     paths:
     - 'Dockerfile'

--- a/.github/workflows/ngsa.yaml
+++ b/.github/workflows/ngsa.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - bugfix/jfrog_https
 
     paths:
     - 'Dockerfile'

--- a/ngsa/pom.xml
+++ b/ngsa/pom.xml
@@ -24,13 +24,6 @@
         <java.version>11</java.version>
         <azure.version>2.2.0</azure.version>
     </properties>
-    <repositories>
-        <repository>
-        <id>jcenter-snapshots</id>
-        <name>jcenter</name>
-        <url>https://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -103,17 +96,17 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-spring-webflux</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/ngsa/pom.xml
+++ b/ngsa/pom.xml
@@ -28,7 +28,7 @@
         <repository>
         <id>jcenter-snapshots</id>
         <name>jcenter</name>
-        <url>http://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
+        <url>https://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
         </repository>
     </repositories>
     <dependencies>


### PR DESCRIPTION
- Removed jfrog snapshot repo
  - Using Maven's by default
- Updated Springfox SwaggerUI, Swagger2 and SpringWebflux version (removed SNAPSHOT)

## Tests

- Tested with WebV benchmark.json and browser check on Swagger UI

## Closes

- Closes https://github.com/retaildevcrews/wcnp/issues/242