### PR TITLE
Update Bursting Flags and Headers for ngsa-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Usage:
 
 Options: 
         --help                                                   Show help and usage information
-        --cpu.target.load                                        Target level for bursting metrics (int) [default: 60]
-        --cpu.max.load                                           Max level for bursting metrics (int) [default: 80]
+        --burst-target                                           Target level for bursting metrics (int) [default: 60]
+        --burst-max                                              Max level for bursting metrics (int) [default: 80]
         --dry-run                                                Validates configuration
         --log-level=<trace|info|warn|error|fatal>                Log Level [default: Error]
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Usage:
 
 Options: 
         --help                                                   Show help and usage information
+        --burst-header                                           Enable burst metrics header in healthz and version requests
+        --burst-service                                          Service name for bursting metrics (string) [default: ngsa-java]
         --burst-target                                           Target level for bursting metrics (int) [default: 60]
         --burst-max                                              Max level for bursting metrics (int) [default: 80]
         --dry-run                                                Validates configuration

--- a/ngsa/src/main/java/com/cse/ngsa/app/Constants.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/Constants.java
@@ -24,6 +24,8 @@ public final class Constants {
 
   public static final String SECRETS_VOLUME = "secrets";
 
+  public static final String BURST_HEADER_KEY = "X-Load-Feedback";
+
 
   private Constants() {
     // private constructor to hide public constructor

--- a/ngsa/src/main/java/com/cse/ngsa/app/Constants.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/Constants.java
@@ -24,6 +24,7 @@ public final class Constants {
 
   public static final String SECRETS_VOLUME = "secrets";
 
+  public static final String BURST_HEADER_ARGUMENT = "burst-header";
   public static final String BURST_HEADER_KEY = "X-Load-Feedback";
 
   private Constants() {

--- a/ngsa/src/main/java/com/cse/ngsa/app/Constants.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/Constants.java
@@ -26,7 +26,6 @@ public final class Constants {
 
   public static final String BURST_HEADER_KEY = "X-Load-Feedback";
 
-
   private Constants() {
     // private constructor to hide public constructor
   }

--- a/ngsa/src/main/java/com/cse/ngsa/app/config/BuildConfig.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/config/BuildConfig.java
@@ -31,7 +31,7 @@ public class BuildConfig {
     String major = context.getBean(BuildProperties.class).getVersion();
 
     DateTimeFormatter formatter = DateTimeFormatter
-        .ofPattern("MMdd.HHmm")
+        .ofPattern("MMdd-HHmm")
         .withZone(ZoneId.of("UTC"));
 
     String formattedDateTime = formatter.format(buildTime);
@@ -39,7 +39,7 @@ public class BuildConfig {
     if (logger.isInfoEnabled()) {
       logger.info(MessageFormat.format("version {0}.{1}", major, formattedDateTime));
     }
-    return major + "+" + formattedDateTime;
+    return major + "-" + formattedDateTime;
 
   }
 }

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -68,8 +68,8 @@ public class HealthzController {
         String.format("service=%s, current-load=%s, target-load=%s, max-load=%s ",
         environment.getProperty("service.name"),
         cpuLoad,
-        environment.getProperty("cpu.target.load"),
-        environment.getProperty("cpu.max.load")));
+        environment.getProperty("burst-target"),
+        environment.getProperty("burst-max")));
 
     return resultsMono.map(data -> {
       String healthStatus = getOverallHealthStatus(data);

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -67,7 +67,9 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-    headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+    if (environment.getProperty("burst-header") != null) {
+      headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+    }
 
     return resultsMono.map(data -> {
       String healthStatus = getOverallHealthStatus(data);
@@ -109,7 +111,9 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-    headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+    if (environment.getProperty("burst-header") != null) {
+      headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+    }
 
     return resultsMono.map(data -> {
       ieTfResult.put(STATUS_TEXT, getOverallHealthStatus(data));

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -108,13 +108,16 @@ public class HealthzController {
 
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+
     return resultsMono.map(data -> {
       ieTfResult.put(STATUS_TEXT, getOverallHealthStatus(data));
       Map<String, Object> resultsDictionary = convertResultsListToDictionary(data);
 
       ieTfResult.put("checks", resultsDictionary);
       return ieTfResult;
-    }).map(result -> ResponseEntity.ok().body(result));
+    }).map(result -> ResponseEntity.ok().headers(headers).body(result));
   }
 
   /** buildHelthCheckChain build the chain of calls using concatWith. */

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -67,7 +67,7 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-    if (environment.getProperty("burst-header") != null) {
+    if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT) != null) {
       headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
     }
 
@@ -111,7 +111,7 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-    if (environment.getProperty("burst-header") != null) {
+    if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT) != null) {
       headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
     }
 

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -6,7 +6,7 @@ import com.cse.ngsa.app.dao.ActorsDao;
 import com.cse.ngsa.app.dao.GenresDao;
 import com.cse.ngsa.app.dao.MoviesDao;
 import com.cse.ngsa.app.health.ietf.IeTfStatus;
-import java.lang.management.ManagementFactory;
+import com.cse.ngsa.app.utils.CommonUtils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -36,14 +36,20 @@ public class HealthzController {
 
   @Autowired private BuildConfig buildConfig;
 
-  @Autowired Environment environment;
+  @Autowired
+  CommonUtils commonUtils;
+
+  @Autowired 
+  Environment environment;
 
   @Autowired
   GenresDao genresDao;
 
-  @Autowired MoviesDao moviesDao;
+  @Autowired 
+  MoviesDao moviesDao;
 
-  @Autowired ActorsDao actorsDao;
+  @Autowired 
+  ActorsDao actorsDao;
 
   // Used to update start time to calculate duration.
   // Using a list, because the variable must be final when used in the map.
@@ -61,15 +67,7 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-    long cpuLoad = Math.round(ManagementFactory.getPlatformMXBean(
-            com.sun.management.OperatingSystemMXBean.class).getProcessCpuLoad() * 100L);
-
-    headers.add("X-Load-Feedback",
-        String.format("service=%s, current-load=%s, target-load=%s, max-load=%s ",
-        environment.getProperty("service.name"),
-        cpuLoad,
-        environment.getProperty("burst-target"),
-        environment.getProperty("burst-max")));
+    headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
 
     return resultsMono.map(data -> {
       String healthStatus = getOverallHealthStatus(data);

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
@@ -50,12 +50,14 @@ public class VersionController {
 
       versionResult.put("apiVersion",
           context.getBean(SwaggerConfig.class).getInfo().get("version"));
-      versionResult.put("appVersion", 
+      versionResult.put("appVersion",
           context.getBean(BuildConfig.class).getBuildVersion());
       versionResult.put("language", "java");
 
       response.setStatusCode(HttpStatus.OK);
-      response.getHeaders().add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+      if (environment.getProperty("burst-header") != null) {
+        response.getHeaders().add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+      }
       
       return Mono.just(versionResult);
     } catch (Exception ex) {

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
@@ -1,14 +1,16 @@
 package com.cse.ngsa.app.controllers;
 
-
+import com.cse.ngsa.app.Constants;
 import com.cse.ngsa.app.config.BuildConfig;
 import com.cse.ngsa.app.config.SwaggerConfig;
+import com.cse.ngsa.app.utils.CommonUtils;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -24,6 +26,12 @@ public class VersionController {
 
   @Autowired
   ApplicationContext context;
+
+  @Autowired
+  CommonUtils commonUtils;
+
+  @Autowired 
+  Environment environment;
 
   /**
    * Returns the application build version.
@@ -47,6 +55,8 @@ public class VersionController {
       versionResult.put("language", "java");
 
       response.setStatusCode(HttpStatus.OK);
+      response.getHeaders().add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
+      
       return Mono.just(versionResult);
     } catch (Exception ex) {
       logger.error("Error received in VersionController", ex);

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
@@ -55,7 +55,7 @@ public class VersionController {
       versionResult.put("language", "java");
 
       response.setStatusCode(HttpStatus.OK);
-      if (environment.getProperty("burst-header") != null) {
+      if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT) != null) {
         response.getHeaders().add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
       }
       

--- a/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -144,6 +144,8 @@ public class CommonUtils {
         + "\tmvn clean spring-boot:run -Dspring-boot.run.arguments=[options] \r\n"
         + "\r\nOptions: \r\n"
         + "\t--help                                    \t\t Show help and usage information\r\n"
+        + "\t--burst-header                             "
+        + "\t\t Enable burst metrics header in healthz and version requests\r\n"
         + "\t--burst-service                             "
         + "\t\t Service name for bursting metrics (string) [default: ngsa-java]\r\n"
         + "\t--burst-target                             "

--- a/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -144,6 +144,8 @@ public class CommonUtils {
         + "\tmvn clean spring-boot:run -Dspring-boot.run.arguments=[options] \r\n"
         + "\r\nOptions: \r\n"
         + "\t--help                                    \t\t Show help and usage information\r\n"
+        + "\t--burst-service                             "
+        + "\t\t Service name for bursting metrics (string) [default: ngsa-java]\r\n"
         + "\t--burst-target                             "
         + "\t\t Target level for bursting metrics (int) [default: 60]\r\n"
         + "\t--burst-max                                "
@@ -169,7 +171,7 @@ public class CommonUtils {
 
     String burstHeaderValue = String.format(
         "service=%s, current-load=%s, target-load=%s, max-load=%s ",
-        environment.getProperty("service.name"),
+        environment.getProperty("burst-service"),
         cpuLoad,
         environment.getProperty("burst-target"),
         environment.getProperty("burst-max"));

--- a/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -68,7 +68,6 @@ public class CommonUtils {
     }
   }
 
-
   private static Level setLogLevel(String logLevel) {
     switch (logLevel) {
       case "trace":
@@ -140,9 +139,9 @@ public class CommonUtils {
         + "\tmvn clean spring-boot:run -Dspring-boot.run.arguments=[options] \r\n"
         + "\r\nOptions: \r\n"
         + "\t--help                                    \t\t Show help and usage information\r\n"
-        + "\t--cpu.target.load                         "
+        + "\t--burst-target                             "
         + "\t\t Target level for bursting metrics (int) [default: 60]\r\n"
-        + "\t--cpu.max.load                            "
+        + "\t--burst-max                                "
         + "\t\t Max level for bursting metrics (int) [default: 80]\r\n"
         + "\t--dry-run                                 \t\t Validates configuration\r\n"
         + "\t--log-level=<trace|info|warn|error|fatal> \t\t Log Level [default: Error]\r\n"

--- a/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -5,6 +5,7 @@ import com.cse.ngsa.app.config.BuildConfig;
 import com.cse.ngsa.app.services.volumes.IVolumeSecretService;
 import com.cse.ngsa.app.services.volumes.Secrets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.lang.management.ManagementFactory;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import javax.annotation.PostConstruct;
@@ -12,6 +13,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
+import org.springframework.core.env.Environment;
 import org.springframework.core.env.SimpleCommandLinePropertySource;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +25,9 @@ public class CommonUtils {
 
   @Autowired
   BuildConfig buildConfig;
+
+  @Autowired 
+  Environment environment;
 
   private CommonUtils() {
     // disable constructor for utility class
@@ -153,6 +158,23 @@ public class CommonUtils {
    */
   public static boolean isNullWhiteSpace(final String string) {
     return string == null || string.isEmpty() || string.trim().isEmpty();
+  }
+
+  /**
+   * Prepares burst header values.
+   */
+  public String getBurstHeaderValue() {
+    long cpuLoad = Math.round(ManagementFactory.getPlatformMXBean(
+        com.sun.management.OperatingSystemMXBean.class).getProcessCpuLoad() * 100L);
+
+    String burstHeaderValue = String.format(
+        "service=%s, current-load=%s, target-load=%s, max-load=%s ",
+        environment.getProperty("service.name"),
+        cpuLoad,
+        environment.getProperty("burst-target"),
+        environment.getProperty("burst-max"));
+    
+    return burstHeaderValue;
   }
 
 }

--- a/ngsa/src/main/resources/application.properties
+++ b/ngsa/src/main/resources/application.properties
@@ -15,5 +15,5 @@ spring.banner.location=classpath:static/startup-banner.txt
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=10s
 
-cpu.target.load=60
-cpu.max.load=80
+burst-target=60
+burst-max=80

--- a/ngsa/src/main/resources/application.properties
+++ b/ngsa/src/main/resources/application.properties
@@ -15,5 +15,6 @@ spring.banner.location=classpath:static/startup-banner.txt
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=10s
 
+burst-service=ngsa-java
 burst-target=60
 burst-max=80


### PR DESCRIPTION
- Update for ngsa-app to uses `--burst-target` and `--burst-max` from `cpu-target` and `cpu-max`
- Updated docs to reflect new args
- Udated version format to match C# app `version-MMdd-HHmm`
- Added burst headers for `/version` and `healthz/ietf` end points
- Moved burst header formatter to `CommonUtils.java`
- Added additional args `burst-header` and `burst-service` support
- Closes https://github.com/retaildevcrews/wcnp/issues/227
