### PR TITLE
Request Logger CLI Args and level change

### DIFF
--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/ActorsController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/ActorsController.java
@@ -55,7 +55,7 @@ public class ActorsController extends Controller {
           .switchIfEmpty(Mono.defer(() ->
             Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Actor Not Found"))));
     } else {
-      logger.error(MessageFormat.format("Invalid Actor ID parameter {0}", actorId));
+      logger.warn(MessageFormat.format("Invalid Actor ID parameter {0}", actorId));
 
       String invalidResponse = super.invalidParameterResponses
           .invalidActorDirectReadResponse(request.getURI().getPath());
@@ -86,7 +86,7 @@ public class ActorsController extends Controller {
       String instance = uri.getPath() + "?" + uri.getQuery();
       return super.getAll(query,pageNumber, pageSize, dao, instance);
     } catch (Exception ex) {
-      logger.error(MessageFormat.format("ActorControllerException {0}", ex.getMessage()));
+      logger.warn(MessageFormat.format("ActorControllerException {0}", ex.getMessage()));
       return Flux.error(new ResponseStatusException(
           HttpStatus.INTERNAL_SERVER_ERROR, Constants.ACTOR_CONTROLLER_EXCEPTION));
     }

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/BenchmarkController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/BenchmarkController.java
@@ -53,7 +53,7 @@ public class BenchmarkController extends Controller {
 
       String invalidResponse = super.invalidParameterResponses
           .invalidBenchmarkSizeResponse(request.getURI().getPath());
-      logger.error("Benchmark data size parameter should be 0 < size <= 1024*1024");
+      logger.warn("Benchmark data size parameter should be 0 < size <= 1024*1024");
 
       return Mono.just(ResponseEntity.badRequest()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/Controller.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/Controller.java
@@ -48,7 +48,7 @@ public class Controller {
       if (Boolean.TRUE.equals(validator.isValidSearchQuery(query.get()))) {
         queryParams.put("q", query.get().trim().toLowerCase().replace("'", "''"));
       } else {
-        logger.error(MessageFormat.format("Invalid Actor Query parameter {0}", query.get()));
+        logger.warn(MessageFormat.format("Invalid Actor Query parameter {0}", query.get()));
         invalidParameters.add(SearchParameter.Q);
       }
     }
@@ -56,7 +56,7 @@ public class Controller {
     Integer pageNo = 0;
     if (pageNumber.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidPageNumber(pageNumber.get()))) {
-        logger.error(MessageFormat.format("Invalid Actor PageNumber parameter {0}",
+        logger.warn(MessageFormat.format("Invalid Actor PageNumber parameter {0}",
             pageNumber.get()));
         invalidParameters.add(SearchParameter.PAGE_NUMBER);
       } else {
@@ -67,7 +67,7 @@ public class Controller {
     Integer pageSz = Constants.DEFAULT_PAGE_SIZE;
     if (pageSize.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidPageSize(pageSize.get()))) {
-        logger.error(MessageFormat.format("Invalid Actor PageSize parameter {0}", pageSize.get()));
+        logger.warn(MessageFormat.format("Invalid Actor PageSize parameter {0}", pageSize.get()));
         invalidParameters.add(SearchParameter.PAGE_SIZE);
       } else {
         pageSz = Integer.parseInt(pageSize.get());
@@ -124,7 +124,7 @@ public class Controller {
         q = query.get().trim().toLowerCase().replace("'", "''");
         queryParams.put("q",q);
       } else {
-        logger.error(MessageFormat.format("Invalid Movie Query parameter {0}", query.get()));
+        logger.warn(MessageFormat.format("Invalid Movie Query parameter {0}", query.get()));
         invalidParameters.add(SearchParameter.Q);
       }
     }
@@ -132,7 +132,7 @@ public class Controller {
     Integer pageNo = 0;
     if (pageNumber.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidPageNumber(pageNumber.get()))) {
-        logger.error(MessageFormat.format("Invalid Movie PageNumber parameter {0}",
+        logger.warn(MessageFormat.format("Invalid Movie PageNumber parameter {0}",
             pageNumber.get()));
         invalidParameters.add(SearchParameter.PAGE_NUMBER);
       } else {
@@ -143,7 +143,7 @@ public class Controller {
     Integer pageSz = Constants.DEFAULT_PAGE_SIZE;
     if (pageSize.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidPageSize(pageSize.get()))) {
-        logger.error(MessageFormat.format("Invalid Movie PageSize parameter {0}", pageSize.get()));
+        logger.warn(MessageFormat.format("Invalid Movie PageSize parameter {0}", pageSize.get()));
         invalidParameters.add(SearchParameter.PAGE_SIZE);
       } else {
         pageSz = Integer.parseInt(pageSize.get());
@@ -153,7 +153,7 @@ public class Controller {
     String movieGenre = "";
     if (genre.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidGenre(genre.get()))) {
-        logger.error(MessageFormat.format("Invalid Movie Genre parameter {0}", genre.get()));
+        logger.warn(MessageFormat.format("Invalid Movie Genre parameter {0}", genre.get()));
         invalidParameters.add(SearchParameter.GENRE);
       } else {
         movieGenre = genre.get();
@@ -164,7 +164,7 @@ public class Controller {
     Integer movieYear = 0;
     if (year.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidYear(year.get()))) {
-        logger.error(MessageFormat.format("Invalid Movie Year parameter {0}", year.get()));
+        logger.warn(MessageFormat.format("Invalid Movie Year parameter {0}", year.get()));
         invalidParameters.add(SearchParameter.YEAR);
       } else {
         movieYear = Integer.parseInt(year.get());
@@ -175,7 +175,7 @@ public class Controller {
     Double movieRating;
     if (rating.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidRating(rating.get()))) {
-        logger.error(MessageFormat.format("Invalid Movie Rating parameter {0}", rating.get()));
+        logger.warn(MessageFormat.format("Invalid Movie Rating parameter {0}", rating.get()));
         invalidParameters.add(SearchParameter.RATING);
       } else {
         movieRating = Double.parseDouble(rating.get());
@@ -186,7 +186,7 @@ public class Controller {
     String movieActorId = "";
     if (actorId.isPresent()) {
       if (Boolean.FALSE.equals(validator.isValidActorId(actorId.get()))) {
-        logger.error(MessageFormat.format("Invalid Movie ActorID parameter {0}", actorId.get()));
+        logger.warn(MessageFormat.format("Invalid Movie ActorID parameter {0}", actorId.get()));
         invalidParameters.add(SearchParameter.ACTOR_ID);
       } else {
         movieActorId = actorId.get();

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/FeaturedController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/FeaturedController.java
@@ -43,7 +43,7 @@ public class FeaturedController {
               });
     } catch (Exception ex) {
 
-      logger.error("Error received in FeaturedController", ex);
+      logger.warn("Error received in FeaturedController", ex);
       return Mono.error(new ResponseStatusException(
         HttpStatus.INTERNAL_SERVER_ERROR, "featured Error"));
     }

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/GenresController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/GenresController.java
@@ -35,7 +35,7 @@ public class GenresController {
       return genresDao.getGenres();
     } catch (Exception ex) {
 
-      logger.error("Error received in GenresController", ex);
+      logger.warn("Error received in GenresController", ex);
       return Mono.error(new ResponseStatusException(
         HttpStatus.INTERNAL_SERVER_ERROR, "genres Error"));
     }

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/MoviesController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/MoviesController.java
@@ -62,7 +62,7 @@ public class MoviesController extends Controller {
                           new ResponseStatusException(HttpStatus.NOT_FOUND, "Movie Not Found"))));
     } else {
 
-      logger.error(MessageFormat.format("Invalid Movie ID parameter {0}", movieId));
+      logger.warn(MessageFormat.format("Invalid Movie ID parameter {0}", movieId));
 
       String invalidResponse = super.invalidParameterResponses
           .invalidMovieDirectReadResponse(request.getURI().getPath());
@@ -90,7 +90,7 @@ public class MoviesController extends Controller {
     if (Boolean.TRUE.equals(validator.isValidMovieId(movieIdOrig) && movieId.startsWith("zz"))) {
       return moviesDao.upsertMovieById(movieIdOrig);
     } else {
-      logger.error(MessageFormat.format("Invalid Movie ID parameter {0}", movieId));
+      logger.warn(MessageFormat.format("Invalid Movie ID parameter {0}", movieId));
       String invalidResponse = super.invalidParameterResponses
               .invalidMovieDeleteResponse(request.getURI().getPath());
       return ResponseEntity.badRequest()
@@ -116,7 +116,7 @@ public class MoviesController extends Controller {
             && movieId.startsWith("zz")) {
       return moviesDao.deleteMovieById(movieId);
     } else {
-      logger.error(MessageFormat.format("Invalid Movie ID parameter {0}", movieId));
+      logger.warn(MessageFormat.format("Invalid Movie ID parameter {0}", movieId));
       String invalidResponse = super.invalidParameterResponses
                   .invalidMovieDeleteResponse(request.getURI().getPath());
       return ResponseEntity.badRequest()
@@ -158,7 +158,7 @@ public class MoviesController extends Controller {
       String instance = uri.getPath() + "?" + uri.getQuery();
       return getAll(query, genre, year, rating, actorId, pageNumber, pageSize, moviesDao, instance);
     } catch (Exception ex) {
-      logger.error(MessageFormat.format("MovieControllerException {0}", ex.getMessage()));
+      logger.warn(MessageFormat.format("MovieControllerException {0}", ex.getMessage()));
       return Flux.error(
           new ResponseStatusException(
               HttpStatus.INTERNAL_SERVER_ERROR, Constants.MOVIE_CONTROLLER_EXCEPTION));

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
@@ -61,7 +61,7 @@ public class VersionController {
       
       return Mono.just(versionResult);
     } catch (Exception ex) {
-      logger.error("Error received in VersionController", ex);
+      logger.warn("Error received in VersionController", ex);
       return Mono.error(new ResponseStatusException(
         HttpStatus.INTERNAL_SERVER_ERROR, "version Error"));
     }

--- a/ngsa/src/main/java/com/cse/ngsa/app/middleware/RequestLogger.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/middleware/RequestLogger.java
@@ -1,5 +1,6 @@
 package com.cse.ngsa.app.middleware;
 
+import com.cse.ngsa.app.services.configuration.IConfigurationService;
 import com.cse.ngsa.app.utils.CorrelationVectorExtensions;
 import com.cse.ngsa.app.utils.QueryUtils;
 import com.microsoft.correlationvector.CorrelationVector;
@@ -12,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
@@ -25,6 +27,7 @@ public class RequestLogger implements WebFilter {
 
   private static final Logger logger =   LogManager.getLogger(RequestLogger.class);
 
+  @Autowired private IConfigurationService cfgSvc;
   @Value("${region:dev}") private String ngsaRegion;
   @Value("${zone:dev}") private String ngsaZone;
   @Value("${request-logger:INFO}") private String ngsaRequestLogger;
@@ -104,7 +107,7 @@ public class RequestLogger implements WebFilter {
       logData.put("Zone", ngsaZone);
       logData.put("Region", ngsaRegion);
       // Hardcoding to true, since there are no in-memory
-      logData.put("CosmosName", "True");
+      logData.put("CosmosName", cfgSvc.getConfigEntries().getCosmosName());
       // log results to console
       logger.info(logData.toString());
     });

--- a/ngsa/src/main/java/com/cse/ngsa/app/middleware/RequestLogger.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/middleware/RequestLogger.java
@@ -6,10 +6,13 @@ import com.microsoft.correlationvector.CorrelationVector;
 import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.Arrays;
+import javax.annotation.PostConstruct;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -21,7 +24,21 @@ import reactor.core.publisher.Mono;
 public class RequestLogger implements WebFilter {
 
   private static final Logger logger =   LogManager.getLogger(RequestLogger.class);
- 
+
+  @Value("${region:dev}") private String ngsaRegion;
+  @Value("${zone:dev}") private String ngsaZone;
+  @Value("${request-logger:INFO}") private String ngsaRequestLogger;
+
+  // Suppressing since its invoked when bean is initialized
+  @SuppressWarnings("PMD.UnusedPrivateMethod")
+  @PostConstruct
+  private void setLoggingLevel() {
+
+    // Setting logger level for this class only
+    Configurator.setLevel(this.getClass().getTypeName(),
+        Level.getLevel(ngsaRequestLogger.toUpperCase()));
+  }
+
   /**
    * filter gathers the request and response metadata and logs
    *   the results to console.
@@ -84,9 +101,10 @@ public class RequestLogger implements WebFilter {
       logData.put("Category", categoryAndMode[0]);
       logData.put("SubCategory", categoryAndMode[1]);
       logData.put("Mode", categoryAndMode[2]);
-      logData.put("Zone", "dev"); // TODO: Update all props below
-      logData.put("Region", "dev");
-      logData.put("CosmosName", "in-memory");
+      logData.put("Zone", ngsaZone);
+      logData.put("Region", ngsaRegion);
+      // Hardcoding to true, since there are no in-memory
+      logData.put("CosmosName", "True");
       // log results to console
       logger.info(logData.toString());
     });

--- a/ngsa/src/main/java/com/cse/ngsa/app/services/volumes/Secrets.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/services/volumes/Secrets.java
@@ -7,6 +7,15 @@ public class Secrets {
   private String cosmosKey;
   private String cosmosDatabase;
   private String cosmosCollection;
+  private String cosmosName;
+
+  public String getCosmosName() {
+    return cosmosName;
+  }
+
+  public void setCosmosName(String cosmosName) {
+    this.cosmosName = cosmosName;
+  }
 
   public String getVolume() {
     return volume;

--- a/ngsa/src/main/resources/application.properties
+++ b/ngsa/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 service.name=ngsa-java
-server.port=4120
+server.port=${port}
 
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M \\(%line\\) - %msg%n
+logging.level.root=error
 
 management.endpoints.web.exposure.include=health, info, metrics
 management.endpoints.web.base-path=/
@@ -18,3 +19,9 @@ spring.lifecycle.timeout-per-shutdown-phase=10s
 burst-service=ngsa-java
 burst-target=60
 burst-max=80
+
+# NGSA Properties
+region=dev
+zone=dev
+port=4120
+request-logger=info

--- a/ngsa/src/main/resources/log4j2.properties
+++ b/ngsa/src/main/resources/log4j2.properties
@@ -8,7 +8,7 @@ logger.reactor.name = io.reactivex
 logger.reactor.level = error
 # New Logger for RequestLogger object only
 logger.request.name=com.cse.ngsa.app.middleware.RequestLogger
-logger.request.level=INFO
+# logger.request.level=INFO # Will be set programmatically
 logger.request.appenderRef.stdout.ref=STDOUT_Request
 logger.request.additivity=false
 # New STDOUT Appender for Requestlogger

--- a/ngsa/src/main/resources/log4j2.properties
+++ b/ngsa/src/main/resources/log4j2.properties
@@ -1,7 +1,7 @@
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 logger.app.name=com.cse.ngsa
-logger.app.level=warn
+logger.app.level=error
 logger.netty.name = io.netty
 logger.netty.level = error
 logger.reactor.name = io.reactivex

--- a/ngsa/src/test/resources/application.properties
+++ b/ngsa/src/test/resources/application.properties
@@ -6,5 +6,11 @@
 # which will pick up your local changes when running in dev mode.         #
 ###########################################################################
 
-server.port=4120
+server.port=${port}
 server.error.include-stacktrace=never
+
+# NGSA Properties
+region=dev
+zone=dev
+port=4120
+request-logger=fatal


### PR DESCRIPTION
This PR:

- Fixes error output for all controllers
- Add CLI args for
  - Region
  - Zone
  - Request Logging level
  - Port
- Used regex to get CosmosDBName

## Fixes

The error report from root logger. Currently it would print request loggings along with other log messages from controllers.

With this PR, default logging level is set to `error` except for request logger and all logs in controllers are set to warning.

#### Without this PR:
![image](https://user-images.githubusercontent.com/11367790/124962275-0dae5b00-dfe4-11eb-834a-b6d500f513f6.png)

#### With this PR:
![image](https://user-images.githubusercontent.com/11367790/124973914-c16a1780-dff1-11eb-970b-20e2584cc76b.png)

## CLI Args

Added `--region`, `--zone`, `--request-log-level` and `--port` cli args.

Note that: for request-log-level, request log will print at severity level INFO or below.

### Usage

`docker run -it --rm -v /path/to/secrets:/app/secrets:ro ngsa-java --region=BIGREGION --zone=OZONE`

## Closes

- Closes https://github.com/retaildevcrews/wcnp/issues/214