### PR TITLE
Enable error logs for secret validation failures

### DIFF
--- a/ngsa/src/main/java/com/cse/ngsa/app/services/volumes/VolumeSecretService.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/services/volumes/VolumeSecretService.java
@@ -1,7 +1,6 @@
 package com.cse.ngsa.app.services.volumes;
 
 import com.cse.ngsa.app.Constants;
-import com.cse.ngsa.app.services.configuration.ConfigurationService;
 import com.cse.ngsa.app.utils.CommonUtils;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/ngsa/src/main/java/com/cse/ngsa/app/services/volumes/VolumeSecretService.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/services/volumes/VolumeSecretService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class VolumeSecretService implements IVolumeSecretService {
-  private static final Logger logger =   LogManager.getLogger(ConfigurationService.class);
+  private static final Logger logger = LogManager.getLogger(VolumeSecretService.class);
   private static final Pattern cosmosNamePat = 
       Pattern.compile("^https:\\/\\/(.+)\\.documents\\.azure\\.com.*");
 

--- a/ngsa/src/test/resources/log4j2.properties
+++ b/ngsa/src/test/resources/log4j2.properties
@@ -1,7 +1,7 @@
 rootLogger.level = fatal
 rootLogger.appenderRef.stdout.ref = STDOUT
 logger.app.name=com.cse.ngsa
-logger.app.level=fatal
+logger.app.level=error
 logger.netty.name = io.netty
 logger.netty.level = fatal
 logger.reactor.name = io.reactivex
@@ -16,3 +16,8 @@ appender.console_req.name = STDOUT_Request
 appender.console_req.type = Console
 appender.console_req.layout.type = PatternLayout
 appender.console_req.layout.pattern = %msg%n
+# STDOUT is a ConsoleAppender and uses PatternLayout.
+appender.console.name = STDOUT
+appender.console.type = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M \\(%line\\) - %msg%n


### PR DESCRIPTION
- Fix error logging in `VolumeSecretService` to throw specific error message in case of failure with secret validation.
-  Closes https://github.com/retaildevcrews/ngsa-java/issues/37