### PR TITLE
Fix ngsa-java build issue

### DIFF
--- a/.devcontainer/library-scripts/maven-debian.sh
+++ b/.devcontainer/library-scripts/maven-debian.sh
@@ -11,6 +11,6 @@
 
 set -e
 
-wget http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz 
+wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz 
 tar -xf apache-maven-${MAVEN_VERSION}-bin.tar.gz 
 mv apache-maven-${MAVEN_VERSION}/ apache-maven/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 ARG MAVEN_VERSION=3.6.3
 
 # Install Maven
-RUN wget http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+RUN wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     tar -xf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     mv apache-maven-${MAVEN_VERSION}/ apache-maven/
 


### PR DESCRIPTION
Updated the Maven link to `https://archive.apache.org`

- Tested in docker build
- Ran ngsa-java from docker and tested with webv


## Issues

- Closes https://github.com/retaildevcrews/wcnp/issues/268