### PR TITLE
Update devcontainer to use ghcr.io

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "ngsa-java",
   // Using prebuilt image by default, uncomment build field below to use local Dockerfile instead
-  "image": "retaildevcrew/ngsa-java-codespaces",
+  "image": "ghcr.io/retaildevcrews/ngsa-java-codespaces",
   
   // Build based on local Dockerfile
   /*

--- a/.github/workflows/ngsa-devcontainer.yaml
+++ b/.github/workflows/ngsa-devcontainer.yaml
@@ -1,0 +1,37 @@
+name: Build NGSA-Java devcontainer for codespaces
+
+on:
+  push:
+    branches:
+      - main
+
+    paths:
+    - '.devcontainer/Dockerfile'
+    - '.github/workflows/ngsa-devcontainer.yaml'
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-20.04
+    env:
+      DOCKER_REPO: ghcr.io/retaildevcrews/ngsa-java-codespaces
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.GHCR_ID }}
+        password: ${{ secrets.GHCR_PAT }}
+
+    - name: Docker Build
+      run: |
+            docker build . --progress tty -t image -f .devcontainer/Dockerfile
+
+    - name: Docker Tag and Push
+      run: |
+        docker tag image $DOCKER_REPO
+        docker push -a $DOCKER_REPO


### PR DESCRIPTION
- Added new workflow to build the devcontainer image and push to ghcr
- Updated devcontainer reference to use ghcr instead of dockerhub

## Issues

- Closes https://github.com/retaildevcrews/wcnp/issues/256