### PR TITLE
Move CLI args to env variables and app.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Options:
         --log-level=<trace|info|warn|error|fatal>            Log Level [default: Error]
               
 Env vars:
-        BURST_HEADER=<true|false>                            Enable burst metrics header in healthz and version requests [default: false]
+        BURST_HEADER=<true|false>                            Enable bursting metrics [default: false]
         BURST_SERVICE                                        Service name for bursting metrics (string) [default: ngsa-java]
         BURST_TARGET                                         Target level for bursting metrics (int) [default: 60]
         BURST_MAX                                            Max level for bursting metrics (int) [default: 80]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Options:
         --dry-run                                                Validates configuration
         --log-level=<trace|info|warn|error|fatal>                Log Level [default: Error]
               
-
 Env vars:
         BURST_HEADER=<true|false>                            Enable burst metrics header in healthz and version requests [default: false]
         BURST_SERVICE                                        Service name for bursting metrics (string) [default: ngsa-java]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ NGSA Java App is inteneded for platform testing and monitoring in one or many Ku
 
 ## Ngsa-java Usage
 
+> NOTE: Command-line arguments take precedence over `application.properties` values and env vars.
+
 ```text
 
 Usage:
@@ -28,13 +30,18 @@ Options:
         --version                                            Shows version information
         --dry-run                                            Validates configuration
         --log-level=<trace|info|warn|error|fatal>            Log Level [default: Error]
+        --burst-header=<true|false>                                      nable bursting metrics [default: false]
+        --burst-service                                      Service name for bursting metrics (string) [default: ngsa-java]
+        --burst-target                                       Target level for bursting metrics (int) [default: 60]
+        --burst-max                                          Max level for bursting metrics (int) [default: 80]
+        --prometheus=<true|false>                            Enable prometheus metrics [default: false]
               
 Env vars:
-        BURST_HEADER=<true|false>                            Enable bursting metrics [default: false]
-        BURST_SERVICE                                        Service name for bursting metrics (string) [default: ngsa-java]
-        BURST_TARGET                                         Target level for bursting metrics (int) [default: 60]
-        BURST_MAX                                            Max level for bursting metrics (int) [default: 80]
-        PROMETHEUS=<true|false>                              Enable prometheus metrics [default: false]
+        BURST_HEADER=<true|false>
+        BURST_SERVICE                                        
+        BURST_TARGET                                         
+        BURST_MAX                                            
+        PROMETHEUS=<true|false>                              
 ```
 
 ## Run the Application

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Options:
         --version                                            Shows version information
         --dry-run                                            Validates configuration
         --log-level=<trace|info|warn|error|fatal>            Log Level [default: Error]
-        --burst-header=<true|false>                                      nable bursting metrics [default: false]
+        --burst-header=<true|false>                          Enable bursting metrics [default: false]
         --burst-service                                      Service name for bursting metrics (string) [default: ngsa-java]
         --burst-target                                       Target level for bursting metrics (int) [default: 60]
         --burst-max                                          Max level for bursting metrics (int) [default: 80]

--- a/README.md
+++ b/README.md
@@ -22,14 +22,17 @@ Usage:
 
 Options: 
         --help                                                   Show help and usage information
-        --burst-header                                           Enable burst metrics header in healthz and version requests
-        --burst-service                                          Service name for bursting metrics (string) [default: ngsa-java]
-        --burst-target                                           Target level for bursting metrics (int) [default: 60]
-        --burst-max                                              Max level for bursting metrics (int) [default: 80]
+        --version                                                Shows version information
         --dry-run                                                Validates configuration
         --log-level=<trace|info|warn|error|fatal>                Log Level [default: Error]
-        --version                                                Shows version information       
+              
 
+Env vars:
+        BURST_HEADER=<true|false>                            Enable burst metrics header in healthz and version requests [default: false]
+        BURST_SERVICE                                        Service name for bursting metrics (string) [default: ngsa-java]
+        BURST_TARGET                                         Target level for bursting metrics (int) [default: 60]
+        BURST_MAX                                            Max level for bursting metrics (int) [default: 80]
+        PROMETHEUS=<true|false>                              Enable prometheus metrics [default: false]
 ```
 
 ## Run the Application

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Usage:
         mvn clean spring-boot:run -Dspring-boot.run.arguments=[options] 
 
 Options: 
-        --help                                                   Show help and usage information
-        --version                                                Shows version information
-        --dry-run                                                Validates configuration
-        --log-level=<trace|info|warn|error|fatal>                Log Level [default: Error]
+        --help                                               Show help and usage information
+        --version                                            Shows version information
+        --dry-run                                            Validates configuration
+        --log-level=<trace|info|warn|error|fatal>            Log Level [default: Error]
               
 Env vars:
         BURST_HEADER=<true|false>                            Enable burst metrics header in healthz and version requests [default: false]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ NGSA Java App is inteneded for platform testing and monitoring in one or many Ku
 ```text
 
 Usage:
-        mvn clean spring-boot:run -Dspring-boot.run.arguments=[options] 
+        mvn clean spring-boot:run -Dspring-boot.run.arguments=[options]
+        
+        export [env var]=<value>
+        mvn clean spring-boot:run
 
 Options: 
         --help                                               Show help and usage information

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/HealthzController.java
@@ -67,7 +67,7 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-    if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT) != null) {
+    if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT).equalsIgnoreCase("true")) {
       headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
     }
 
@@ -111,7 +111,7 @@ public class HealthzController {
     Mono<List<Map<String, Object>>> resultsMono = buildHealthCheckChain();
 
     HttpHeaders headers = new HttpHeaders();
-    if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT) != null) {
+    if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT).equalsIgnoreCase("true")) {
       headers.add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
     }
 

--- a/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/controllers/VersionController.java
@@ -55,7 +55,7 @@ public class VersionController {
       versionResult.put("language", "java");
 
       response.setStatusCode(HttpStatus.OK);
-      if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT) != null) {
+      if (environment.getProperty(Constants.BURST_HEADER_ARGUMENT).equalsIgnoreCase("true")) {
         response.getHeaders().add(Constants.BURST_HEADER_KEY, commonUtils.getBurstHeaderValue());
       }
       

--- a/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -150,17 +150,22 @@ public class CommonUtils {
         + "\t--version                                 \t\t Show version information\r\n"
         + "\t--dry-run                                 \t\t Validates configuration\r\n"
         + "\t--log-level=<trace|info|warn|error|fatal> \t\t Log Level [default: Error]\r\n"
-        + "\r\nEnv vars: \r\n"
-        + "\tBURST_HEADER=<true|false>                 "
+        + "\t--burst-header                            "
         + "\t\t Enable bursting metrics [env var: ENV_BURST_HEADER; default: false]\r\n"
-        + "\tBURST_SERVICE                             "
+        + "\t--burst-service=<true|false>              "
         + "\t\t Service name for bursting metrics (string) [default: ngsa-java]\r\n"
-        + "\tBURST_TARGET                              "
+        + "\t--burst-target                            "
         + "\t\t Target level for bursting metrics (int) [default: 60]\r\n"
-        + "\tBURST_MAX                                 "
+        + "\t--burst-max                               "
         + "\t\t Max level for bursting metrics (int) [default: 80]\r\n"
-        + "\tPROMETHEUS=<true|false>                   "
-        + "\t\t Enable prometheus metrics [default: false]\r\n");
+        + "\t--prometheus=<true|false>                 "
+        + "\t\t Enable prometheus metrics [default: false]\r\n"
+        + "\r\nEnv vars: \r\n"
+        + "\tBURST_HEADER=<true|false> \r\n"
+        + "\tBURST_SERVICE \r\n"
+        + "\tBURST_TARGET \r\n"
+        + "\tBURST_MAX \r\n"
+        + "\tPROMETHEUS=<true|false> \r\n");
   }
 
   /**

--- a/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -144,17 +144,20 @@ public class CommonUtils {
         + "\tmvn clean spring-boot:run -Dspring-boot.run.arguments=[options] \r\n"
         + "\r\nOptions: \r\n"
         + "\t--help                                    \t\t Show help and usage information\r\n"
-        + "\t--burst-header                             "
-        + "\t\t Enable burst metrics header in healthz and version requests\r\n"
-        + "\t--burst-service                             "
-        + "\t\t Service name for bursting metrics (string) [default: ngsa-java]\r\n"
-        + "\t--burst-target                             "
-        + "\t\t Target level for bursting metrics (int) [default: 60]\r\n"
-        + "\t--burst-max                                "
-        + "\t\t Max level for bursting metrics (int) [default: 80]\r\n"
+        + "\t--version                                 \t\t Show version information\r\n"
         + "\t--dry-run                                 \t\t Validates configuration\r\n"
         + "\t--log-level=<trace|info|warn|error|fatal> \t\t Log Level [default: Error]\r\n"
-        + "\t--version                                 \t\t Show version information\r\n");
+        + "\r\nEnv vars: \r\n"
+        + "\tBURST_HEADER=<true|false>                 "
+        + "\t\t Enable bursting metrics [env var: ENV_BURST_HEADER; default: false]\r\n"
+        + "\tBURST_SERVICE                             "
+        + "\t\t Service name for bursting metrics (string) [default: ngsa-java]\r\n"
+        + "\tBURST_TARGET                              "
+        + "\t\t Target level for bursting metrics (int) [default: 60]\r\n"
+        + "\tBURST_MAX                                 "
+        + "\t\t Max level for bursting metrics (int) [default: 80]\r\n"
+        + "\tPROMETHEUS=<true|false>                   "
+        + "\t\t Enable prometheus metrics [default: false]\r\n");
   }
 
   /**

--- a/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
+++ b/ngsa/src/main/java/com/cse/ngsa/app/utils/CommonUtils.java
@@ -142,6 +142,9 @@ public class CommonUtils {
   public static void printCmdLineHelp() {
     System.out.println("\r\nUsage:\r\n"
         + "\tmvn clean spring-boot:run -Dspring-boot.run.arguments=[options] \r\n"
+        + "\r\n"
+        + "\texport [env var]=<value> \r\n"
+        + "\tmvn clean spring-boot:run \r\n"
         + "\r\nOptions: \r\n"
         + "\t--help                                    \t\t Show help and usage information\r\n"
         + "\t--version                                 \t\t Show version information\r\n"

--- a/ngsa/src/main/resources/application.properties
+++ b/ngsa/src/main/resources/application.properties
@@ -37,13 +37,14 @@ spring.banner.location=classpath:static/startup-banner.txt
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=10s
 
-burst-service=ngsa-java
-burst-target=60
-burst-max=80
+burst-service=${BURST_SERVICE:ngsa-java}
+burst-target=${BURST_TARGET:60}
+burst-max=${BURST_MAX:80}
+burst-header=${BURST_HEADER:false}
 
 # Ngsa specific properties
 region=dev
 zone=dev
 port=8080
 request-log-level=info
-prometheus=false
+prometheus=${PROMETHEUS:false}


### PR DESCRIPTION
- Make  CLI args configurable by setting env vars and referencing to `application.properties`
- Updated help usage 
- Updated readme
- Closes https://github.com/retaildevcrews/ngsa-java/issues/45